### PR TITLE
Add aiken-mode to editor integration list

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -29,7 +29,8 @@ This Github organization references all core projects related to Aiken.
   | Editor     | Repository                                                                             |
   | ---        | ---                                                                                    |
   | vim/neovim | [`editor-integration-nvim`](https://github.com/aiken-lang/editor-integration-nvim)     |
-  | VSCode     | [`vscode-aiken`](https://github.com/aiken-lang/vscode-aiken) |
+  | VSCode     | [`vscode-aiken`](https://github.com/aiken-lang/vscode-aiken)                           |
+  | emacs      | [`aiken-mode`](https://github.com/ch1bo/aiken-mode)                                    |
 
 ## <img src="https://raw.githubusercontent.com/CardanoSolutions/ogmios/master/.github/twitter.svg" height="32" /> Follow us
 


### PR DESCRIPTION
I created an emacs major mode for aiken. Currently only doing syntax highlighting, but indentation, formatting and other command integrations are planned.

Happy to move the aiken-mode repository into the aiken-lang organization if wanted.